### PR TITLE
WDT crash detection

### DIFF
--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -950,8 +950,7 @@ void dcode_21()
     {
         KEEPALIVE_STATE(NOT_BUSY);
         DBG(_N("D21 - read crash dump\n"));
-        print_mem(DUMP_OFFSET  + offsetof(dump_t, data),
-                  DUMP_SIZE, dcode_mem_t::xflash);
+        print_mem(DUMP_OFFSET, sizeof(dump_t), dcode_mem_t::xflash);
     }
 }
 

--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -72,7 +72,7 @@ enum class dcode_mem_t:uint8_t { sram, eeprom, progmem, xflash };
 
 void print_mem(daddr_t address, daddr_t count, dcode_mem_t type, uint8_t countperline = 16)
 {
-#if defined(DEBUG_DCODE6) || defined(DEBUG_DCODES)
+#if defined(DEBUG_DCODE6) || defined(DEBUG_DCODES) || defined(XFLASH_DUMP)
     if(type == dcode_mem_t::xflash)
         XFLASH_SPI_ENTER();
 #endif
@@ -89,7 +89,7 @@ void print_mem(daddr_t address, daddr_t count, dcode_mem_t type, uint8_t countpe
 			case dcode_mem_t::sram: data = *((uint8_t*)address); break;
 			case dcode_mem_t::eeprom: data = eeprom_read_byte((uint8_t*)address); break;
 			case dcode_mem_t::progmem: break;
-#if defined(DEBUG_DCODE6) || defined(DEBUG_DCODES)
+#if defined(DEBUG_DCODE6) || defined(DEBUG_DCODES) || defined(XFLASH_DUMP)
             case dcode_mem_t::xflash: xflash_rd_data(address, &data, 1); break;
 #else
             case dcode_mem_t::xflash: break;

--- a/Firmware/Dcodes.cpp
+++ b/Firmware/Dcodes.cpp
@@ -935,9 +935,9 @@ void dcode_20()
         xfdump_full_dump_and_reset();
     else
     {
-        unsigned long ts = millis();
+        unsigned long ts = _millis();
         xfdump_dump();
-        ts = millis() - ts;
+        ts = _millis() - ts;
         DBG(_N("dump completed in %lums\n"), ts);
     }
 }

--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1667,6 +1667,9 @@ void setup()
   KEEPALIVE_STATE(NOT_BUSY);
 #ifdef WATCHDOG
   wdt_enable(WDTO_4S);
+#ifdef XFLASH_DUMP
+  WDTCSR |= (1 << WDIE);
+#endif //XFLASH_DUMP
 #endif //WATCHDOG
 }
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -1811,6 +1811,12 @@ static void lcd_dump_memory()
     xfdump_dump();
     lcd_return_to_status();
 }
+
+static void lcd_wdr_crash()
+{
+    while (1);
+}
+
 #endif
 
 
@@ -2007,6 +2013,7 @@ static void lcd_support_menu()
 
 #ifdef MENU_DUMP
     MENU_ITEM_FUNCTION_P(_i("Dump memory"), lcd_dump_memory);
+    MENU_ITEM_FUNCTION_P(PSTR("WDR crash"), lcd_wdr_crash);
 #endif
 #ifdef DEBUG_BUILD
   MENU_ITEM_SUBMENU_P(PSTR("Debug"), lcd_menu_debug);////MSG_DEBUG c=18
@@ -6704,7 +6711,7 @@ static void lcd_main_menu()
 void stack_error() {
     WRITE(BEEPER, HIGH);
     eeprom_update_byte((uint8_t*)EEPROM_CRASH_ACKNOWLEDGED, 0);
-    xfdump_full_dump_and_reset(true);
+    xfdump_full_dump_and_reset(dump_crash_source::stack_error);
 }
 #else
 void stack_error() {

--- a/Firmware/xflash_dump.h
+++ b/Firmware/xflash_dump.h
@@ -8,7 +8,14 @@ bool xfdump_check_state();  // return true if a dump is present
 bool xfdump_check_crash();  // return true if a dump is present and is a crash dump
 void xfdump_dump();         // create a new SRAM memory dump
 
+enum class dump_crash_source : uint8_t
+{
+    manual = 0,
+    stack_error,
+    watchdog,
+};
+
 // create a new dump containing registers and SRAM, then reset
-void xfdump_full_dump_and_reset(bool crash = false);
+void xfdump_full_dump_and_reset(dump_crash_source crash = dump_crash_source::manual);
 
 #endif

--- a/Firmware/xflash_layout.h
+++ b/Firmware/xflash_layout.h
@@ -20,7 +20,7 @@ struct dump_header_t
     uint32_t magic;
 
     uint8_t regs_present; // true when the lower segment containing registers is present
-    uint8_t crash;        // true if triggered by EMERGENCY_DUMP
+    uint8_t crash_type; // uses values from dump_crash_source
 };
 
 struct dump_data_t

--- a/Firmware/xyzcal.cpp
+++ b/Firmware/xyzcal.cpp
@@ -163,6 +163,9 @@ void xyzcal_meassure_leave(void)
 	ENABLE_STEPPER_DRIVER_INTERRUPT();
 #ifdef WATCHDOG
 	wdt_enable(WDTO_4S);
+#ifdef XFLASH_DUMP
+	WDTCSR |= (1 << WDIE);
+#endif //XFLASH_DUMP
 #endif //WATCHDOG
 	sm4_stop_cb = 0;
 	sm4_update_pos_cb = 0;


### PR DESCRIPTION
I modified the header a bit so that instead of just showing whether it was a crash or not, it shows the source of the crash. As such, there can be 3 sources: Manual (not a crash), stack_error and watchdog.
I also added an ISR for the watchdog interrupt and enabled it throughout the code. When the interrupt occurs, we dump as well and then reset. I also changed the D21 code so that it dumps the entire header as well. Scripts need to be updated for this to make sense. I did this because I wanted to have the crash source in the dump as well, not only in the firmware.

I also fixed two other things:
- wrong millis was used. You linked against the arduino millis, not the timer2 millis. Please use the macros with '_' at the beginning.
- At first the dumping wasn't working for me, but I later found out that the printmem function didn't have the XFLASH functionality enabled just with the three XDUMP defines. So I modified the IFs a bit.