### PR TITLE
Prevent double messages

### DIFF
--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -17,6 +17,7 @@ LANGUAGES+=" nl" #Dutch
 
 # insert single text to english dictionary
 # $1 - text to insert
+# $2 - metadata
 insert_en()
 {
 	#replace '[' and ']' in string with '\[' and '\]'
@@ -29,12 +30,13 @@ insert_en()
 	# insert new text
 	sed -i "$ln"'i\\' lang_en.txt
 	sed -i "$ln"'i\'"$1"'\' lang_en.txt
-	sed -i "$ln"'i\#\' lang_en.txt
+	sed -i "${ln}i\\#$2" lang_en.txt
 }
 
 # insert single text to translated dictionary
 # $1 - text to insert
-# $2 - sufix
+# $2 - suffix
+# $3 - metadata
 insert_xx()
 {
 	#replace '[' and ']' in string with '\[' and '\]'
@@ -48,7 +50,15 @@ insert_xx()
 	sed -i "$ln"'i\\' lang_en_$2.txt
 	sed -i "$ln"'i\"\x00"\' lang_en_$2.txt
 	sed -i "$ln"'i\'"$1"'\' lang_en_$2.txt
-	sed -i "$ln"'i\#\' lang_en_$2.txt
+	sed -i "${ln}i\\#$3" lang_en_$2.txt
+}
+
+# find the metadata for the specified string
+# TODO: this is unbeliveably crude
+# $1 - text to search for
+find_metadata()
+{
+    sed -ne "s^.*\(_[iI]\|ISTR\)($1).*////\(.*\)^\2^p" ../Firmware/*.[ch]* | head -1
 }
 
 # check if input file exists
@@ -63,13 +73,14 @@ cat lang_add.txt | sed 's/^/"/;s/$/"/' | while read new_s; do
 		echo "$new_s"
 		echo
 	else
+		meta=$(find_metadata "$new_s")
 		echo "adding text:"
-		echo "$new_s"
+		echo "$new_s ($meta)"
 		echo
 
-		insert_en "$new_s"
+		insert_en "$new_s" "$meta"
         for lang in $LANGUAGES; do
-            insert_xx "$new_s" "$lang"
+            insert_xx "$new_s" "$lang" "$meta"
         done
 	fi
 done

--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -22,9 +22,10 @@ insert_en()
 	#replace '[' and ']' in string with '\[' and '\]'
 	str=$(echo "$1" | sed "s/\[/\\\[/g;s/\]/\\\]/g")
 	# extract english texts, merge new text, grep line number
-	ln=$((cat lang_en.txt; echo "$1") | sed "/^$/d;/^#/d" | sort | grep -n "$str" | sed "s/:.*//")
+	ln=$((cat lang_en.txt; echo "$1") | sed "/^$/d;/^#/d" | sort | grep -n "$str" | sed "s/:.*//;q")
 	# calculate position for insertion
 	ln=$((3*(ln-2)+1))
+	[ "$ln" -lt 1 ] && ln=1
 	# insert new text
 	sed -i "$ln"'i\\' lang_en.txt
 	sed -i "$ln"'i\'"$1"'\' lang_en.txt
@@ -39,9 +40,10 @@ insert_xx()
 	#replace '[' and ']' in string with '\[' and '\]'
 	str=$(echo "$1" | sed "s/\[/\\\[/g;s/\]/\\\]/g")
 	# extract english texts, merge new text, grep line number
-	ln=$((cat lang_en_$2.txt; echo "$1") | sed "/^$/d;/^#/d" | sed -n 'p;n' | sort | grep -n "$str" | sed "s/:.*//")
+	ln=$((cat lang_en_$2.txt; echo "$1") | sed "/^$/d;/^#/d" | sed -n 'p;n' | sort | grep -n "$str" | sed "s/:.*//;q")
 	# calculate position for insertion
 	ln=$((4*(ln-2)+1))
+	[ "$ln" -lt 1 ] && ln=1
 	# insert new text
 	sed -i "$ln"'i\\' lang_en_$2.txt
 	sed -i "$ln"'i\"\x00"\' lang_en_$2.txt

--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -7,7 +7,12 @@
 #  lang_add.txt
 # Updated files:
 #  lang_en.txt and all lang_en_xx.txt
-#
+
+# List of supported languages
+LANGUAGES="cz de es fr it pl"
+
+# Community languages
+LANGUAGES+=" nl" #Dutch
 
 
 # insert single text to english dictionary
@@ -59,20 +64,11 @@ cat lang_add.txt | sed 's/^/"/;s/$/"/' | while read new_s; do
 		echo "adding text:"
 		echo "$new_s"
 		echo
-		insert_en "$new_s"
-		insert_xx "$new_s" 'cz'
-		insert_xx "$new_s" 'de'
-		insert_xx "$new_s" 'es'
-		insert_xx "$new_s" 'fr'
-		insert_xx "$new_s" 'it'
-		insert_xx "$new_s" 'pl'
-#Community language support
-#Dutch
-		insert_xx "$new_s" 'nl'
 
-#Use the 2 lines below as a template and replace 'qr'
-##New language
-#		insert_xx "$new_s" 'qr'
+		insert_en "$new_s"
+        for lang in $LANGUAGES; do
+            insert_xx "$new_s" "$lang"
+        done
 	fi
 done
 

--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -14,23 +14,78 @@ LANGUAGES="cz de es fr it pl"
 # Community languages
 LANGUAGES+=" nl" #Dutch
 
+# Set defaults
+skip_insert="0"
+
+# check single text in english dictionary
+# $1 - text to check
+# $2 - metadata
+check_en()
+{
+if grep "$1" lang_en.txt >/dev/null; then
+    echo "$(tput setaf 3)text already exist in en:"
+    echo "$1$(tput sgr0)"
+    echo
+    skip_insert="1"
+else
+    skip_insert="0"
+fi
+if [ ! -z "$2" ]; then
+    if grep "$2" lang_en.txt >/dev/null; then
+        echo "$(tput setaf 3)Meta already exist in en:"
+        echo "$2$(tput sgr0)"
+        echo
+        skip_insert="1"
+    else
+        skip_insert="0"
+    fi
+fi
+}
 
 # insert single text to english dictionary
 # $1 - text to insert
 # $2 - metadata
 insert_en()
 {
-	#replace '[' and ']' in string with '\[' and '\]'
-	str=$(echo "$1" | sed "s/\[/\\\[/g;s/\]/\\\]/g")
-	# extract english texts, merge new text, grep line number
-	ln=$((cat lang_en.txt; echo "$1") | sed "/^$/d;/^#/d" | sort | grep -n "$str" | sed "s/:.*//;q")
-	# calculate position for insertion
-	ln=$((3*(ln-2)+1))
-	[ "$ln" -lt 1 ] && ln=1
-	# insert new text
-	sed -i "$ln"'i\\' lang_en.txt
-	sed -i "$ln"'i\'"$1"'\' lang_en.txt
-	sed -i "${ln}i\\#$2" lang_en.txt
+    echo "$(tput sgr0)Inserting meta: $(tput setaf 2)$2$(tput sgr0) text: $(tput setaf 2)$1$(tput sgr0) in $(tput setaf 2)en$(tput sgr0)"
+    #replace '[' and ']' in string with '\[' and '\]'
+    str=$(echo "$1" | sed "s/\[/\\\[/g;s/\]/\\\]/g")
+    # extract english texts, merge new text, grep line number
+    ln=$((cat lang_en.txt; echo "$1") | sed "/^$/d;/^#/d" | sort | grep -n "$str" | sed "s/:.*//;q")
+    # calculate position for insertion
+    ln=$((3*(ln-2)+1))
+    [ "$ln" -lt 1 ] && ln=1
+    # insert new text
+    sed -i "$ln"'i\\' lang_en.txt
+    sed -i "$ln"'i\'"$1"'\' lang_en.txt
+    sed -i "${ln}i\\#$2" lang_en.txt
+}
+
+# check single text in translated dictionary
+# $1 - text to check
+# $2 - suffix
+# $3 - metadata
+check_xx()
+{
+if grep "$1" lang_en_$2.txt >/dev/null; then
+    echo "$(tput setaf 3)text already exist in $2:"
+    echo "$1$(tput sgr0)"
+    echo
+    skip_insert="1"
+else
+    skip_insert="0"
+fi
+#if [[ ! -z "$3" && "$skip_insert"="0" ]]; then
+if [ ! -z "$3" ]; then
+    if grep "$3" lang_en_$2.txt >/dev/null; then
+        echo "$(tput setaf 3)Meta already exist in $2:"
+        echo "$3$(tput sgr0)"
+        echo
+        skip_insert="1"
+    else
+        skip_insert="0"
+    fi
+fi
 }
 
 # insert single text to translated dictionary
@@ -39,18 +94,19 @@ insert_en()
 # $3 - metadata
 insert_xx()
 {
-	#replace '[' and ']' in string with '\[' and '\]'
-	str=$(echo "$1" | sed "s/\[/\\\[/g;s/\]/\\\]/g")
-	# extract english texts, merge new text, grep line number
-	ln=$((cat lang_en_$2.txt; echo "$1") | sed "/^$/d;/^#/d" | sed -n 'p;n' | sort | grep -n "$str" | sed "s/:.*//;q")
-	# calculate position for insertion
-	ln=$((4*(ln-2)+1))
-	[ "$ln" -lt 1 ] && ln=1
-	# insert new text
-	sed -i "$ln"'i\\' lang_en_$2.txt
-	sed -i "$ln"'i\"\x00"\' lang_en_$2.txt
-	sed -i "$ln"'i\'"$1"'\' lang_en_$2.txt
-	sed -i "${ln}i\\#$3" lang_en_$2.txt
+    echo "$(tput sgr0)Inserting meta: $(tput setaf 2)$3$(tput sgr0) text: $(tput setaf 2)$1$(tput sgr0) in $(tput setaf 2)$2$(tput sgr0)"
+    #replace '[' and ']' in string with '\[' and '\]'
+    str=$(echo "$1" | sed "s/\[/\\\[/g;s/\]/\\\]/g")
+    # extract english texts, merge new text, grep line number
+    ln=$((cat lang_en_$2.txt; echo "$1") | sed "/^$/d;/^#/d" | sed -n 'p;n' | sort | grep -n "$str" | sed "s/:.*//;q")
+    # calculate position for insertion
+    ln=$((4*(ln-2)+1))
+    [ "$ln" -lt 1 ] && ln=1
+    # insert new text
+    sed -i "$ln"'i\\' lang_en_$2.txt
+    sed -i "$ln"'i\"\x00"\' lang_en_$2.txt
+    sed -i "$ln"'i\'"$1"'\' lang_en_$2.txt
+    sed -i "${ln}i\\#$3" lang_en_$2.txt
 }
 
 # find the metadata for the specified string
@@ -63,26 +119,34 @@ find_metadata()
 
 # check if input file exists
 if ! [ -e lang_add.txt ]; then
-	echo "file lang_add.txt not found"
-	exit 1
+    echo "$(tput setaf 1)file lang_add.txt not found"
+    exit 1
 fi
 
 cat lang_add.txt | sed 's/^/"/;s/$/"/' | while read new_s; do
-	if grep "$new_s" lang_en.txt >/dev/null; then
-		echo "text already exist:"
-		echo "$new_s"
-		echo
-	else
-		meta=$(find_metadata "$new_s")
-		echo "adding text:"
-		echo "$new_s ($meta)"
-		echo
-
-		insert_en "$new_s" "$meta"
+    if grep "$new_s" lang_en.txt >/dev/null; then
+        echo "$(tput setaf 3)text already exist:"
+        echo "$(tput setaf 3)$new_s$(tput sgr0)"
+        echo
+    else
+        meta=$(find_metadata "$new_s")
+        if [ -z "$meta" ]; then
+            echo "$(tput setaf 1)No meta data found for $(tput setaf 3)$new_s$(tput sgr0)"
+        fi
+        echo "$(tput setaf 2)adding text:"
+        echo "$new_s ($meta)$(tput sgr0)"
+        echo
+        check_en "$new_s" "$meta"
+        if [ $skip_insert = "0" ]; then
+            insert_en "$new_s" "$meta"
+        fi
         for lang in $LANGUAGES; do
-            insert_xx "$new_s" "$lang" "$meta"
+            check_xx "$new_s" "$lang" "$meta"
+            if [ $skip_insert = "0" ]; then
+                insert_xx "$new_s" "$lang" "$meta"
+            fi
         done
-	fi
+    fi
 done
 
 read -t 5

--- a/lang/lang-add.sh
+++ b/lang/lang-add.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# Version 1.0.1 Build 18
+#
 # lang-add.sh - multi-language support script
 #  add new texts from list (lang_add.txt) to all dictionary files
 #
@@ -7,6 +9,20 @@
 #  lang_add.txt
 # Updated files:
 #  lang_en.txt and all lang_en_xx.txt
+#
+#############################################################################
+# Change log:
+#  1 Nov 2018,  Xpilla,     Initial
+#  9 June 2020, 3d-gussner, Added version and Change log
+#  9 June 2020, 3d-gussner, colored output
+#  1 Mar. 2021, 3d-gussner, Add Community language support
+#  2 Apr. 2021, 3d-gussner, Use `git rev-list --count HEAD lang-add.sh`
+#                           to get Build Nr
+# 30 June 2021, wavexx    , avoid repetition for supported languages
+#                           handle duplicate translations and empty files
+#                           add a *crude* metadata extractor
+# 30 July 2021, 3d-gussner, Prevent double messages
+#############################################################################
 
 # List of supported languages
 LANGUAGES="cz de es fr it pl"


### PR DESCRIPTION
Added `check_en` and `check_en_xx` functions to prevent a message is added again if it already exists in `lang_en_xx.txt` files.
Added some documentation.
There are 15 files changed as I merged the MK3_3.10.1 branch.
@wavexx Can you please rebase the https://github.com/prusa3d/Prusa-Firmware/pull/3215 from `MK3` branch to `MK3_3.10.1`
Also added some colored output:
- green good
- yellow warning, like meta data not found in source code.
- red not that good



TEST:

1. change to `/lang`
2. Add some missing message from the not_trans_*.txt file to `lang_add.txt`
3. run `lang-add.sh`
4. manually revert the adds in `lang_en.txt`(git restore lang_en.txt)
5. re-run `lang-add.sh`

Before this change and with a "reverted" `lang_en.txt` the `lang_en_xx.txt` get an additional message added.
After this change and with a "reverted"  `lang_en.txt` the `lang_en_xx.txt` will NOT be updated.
